### PR TITLE
fix(api): Correct 'replyTo' property in Resend call

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
       to: ['contacto@hexaservicios.com'],
       subject: `Nuevo mensaje de contacto de: ${name}`,
       html: emailHtml,
-      reply_to: email,
+      replyTo: email,
     });
 
     if (error) {


### PR DESCRIPTION
- Corrects a typo in the `/api/contact` route.
- The `reply_to` property has been changed to the correct `replyTo` (camelCase) as expected by the Resend SDK.
- This fixes the build error and allows the contact form to send emails correctly.