### PR TITLE
fix: Use absolute URL for Open Graph image

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,14 +34,14 @@ export const metadata: Metadata = {
       'Servicios de gestión de proyectos, generación solar, infraestructura eléctrica, frío industrial, climatización e informática.',
     type: 'website',
     url: 'https://hesaservicios.com',
-    images: ['/logo-HEXA.png'],
+    images: ['https://hesaservicios.com/logo-HEXA.png'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'HEXA Servicios Integrales SAS | Ingeniería y Proyectos',
     description:
       'Servicios de gestión de proyectos, generación solar, infraestructura eléctrica, frío industrial, climatización e informática.',
-    images: ['/logo-HEXA.png'],
+    images: ['https://hesaservicios.com/logo-HEXA.png'],
   },
 };
 


### PR DESCRIPTION
- Updates the `og:image` and `twitter:image` URLs in `layout.tsx` to be absolute instead of relative.
- This is a best practice to ensure maximum compatibility with social media crawlers and resolve issues where the preview image may not appear.